### PR TITLE
Add Sherpa channel, pin gammapy 1.3 and fix astropy version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,11 @@
+name: gammapy_mwl
 channels:
 - defaults
 - conda-forge
 dependencies:
-- astropy=0.6.1
+- astropy=6.1
 - astroquery=0.4.7
-- gammapy=1.3.dev726+g6c6d15956
+# - gammapy=1.3.dev726+g6c6d15956
 - matplotlib=3.8.3
 - numpy=1.26.4
 - photutils=1.8.0
@@ -14,5 +15,5 @@ dependencies:
 - regions=0.9
 - requests=2.31.0
 - scipy=1.12.0
-- sherpa=4.16.0
-name: gammapy_mwl
+- pip:
+    - sherpa=4.16.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - astropy=5.3.4
 - astroquery=0.4.7
-# - gammapy=1.3.dev726+g6c6d15956
+- gammapy=1.3
 - matplotlib=3.8.3
 - numpy=1.26.4
 - photutils=1.8.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: gammapy_mwl
 channels:
 - defaults
 - conda-forge
+- https://cxc.cfa.harvard.edu/conda/sherpa
 dependencies:
 - astropy=6.1
 - astroquery=0.4.7
@@ -15,5 +16,4 @@ dependencies:
 - regions=0.9
 - requests=2.31.0
 - scipy=1.12.0
-- pip:
-    - sherpa=4.16.0
+- sherpa=4.16.0


### PR DESCRIPTION
 - Gammapy dev version cannot be installed via conda env creation 
 - Astropy version specified (0.6.1) has to be wrong. It must be 6.1
 - Sherpa is not installable via the conda forge channel, I set it to be installed via pip (within the conda env)